### PR TITLE
Require `composer/installers` v1 or v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Hubspot Form Embed Block for WordPress",
 	"type": "wordpress-plugin",
 	"require": {
-		"composer/installers": "^2.3"
+		"composer/installers": "^1 || ^2"
 	},
 	"license": "gpl-2.0-or-later",
 	"authors": [


### PR DESCRIPTION
Allows the plugin to be installed via Composer on projects using an older version of `composer/installers`.