### PR TITLE
Regional forms script

### DIFF
--- a/hubspot-form-block.php
+++ b/hubspot-form-block.php
@@ -30,9 +30,11 @@ function block_init() {
 add_action( 'init', __NAMESPACE__ . '\\block_init' );
 
 function register_scripts() {
+	$region = get_option( 'hubspot_embed_region', 'eu1' ) === 'eu1' ? 'js-eu1' : 'js';
+
 	wp_register_script(
 		'hs-forms',
-		'https://js.hsforms.net/forms/v2.js',
+		sprintf( 'https://%s.hsforms.net/forms/embed/v2.js', $region ),
 		[],
 		null,
 		[ 'strategy' => 'async' ]
@@ -59,11 +61,11 @@ function enqueue_scripts() {
 		return;
 	}
 
-	$region = get_option( 'hubspot_embed_region', 'eu1' );
+	$region = get_option( 'hubspot_embed_region', 'eu1' ) === 'eu1' ? 'js-eu1' : 'js';
 
 	wp_enqueue_script(
 		'hs-script-loader',
-		sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id ),
+		sprintf( 'https://%s.hs-scripts.com/%s.js', $region, $portal_id ),
 		[],
 		null,
 		[

--- a/src/edit.js
+++ b/src/edit.js
@@ -116,6 +116,14 @@ export default function Edit( { attributes, setAttributes } ) {
 							setAttributes( { region } );
 							setIsGlobalChanged( true );
 						} }
+						help={
+							( region && region !== defaultRegion )
+								? __(
+										'Warning: Region used for this block is not the same as the global default. This may cause issues.',
+										'hubspot-form-block'
+								  )
+								: undefined
+						}
 					/>
 					{ canSetPortalId && isGlobalChanged && (
 						<Button

--- a/src/edit.js
+++ b/src/edit.js
@@ -116,14 +116,6 @@ export default function Edit( { attributes, setAttributes } ) {
 							setAttributes( { region } );
 							setIsGlobalChanged( true );
 						} }
-						help={
-							( region && region !== defaultRegion )
-								? __(
-										'Warning: Region used for this block is not the same as the global default. This may cause issues.',
-										'hubspot-form-block'
-								  )
-								: undefined
-						}
 					/>
 					{ canSetPortalId && isGlobalChanged && (
 						<Button

--- a/src/render.php
+++ b/src/render.php
@@ -2,6 +2,7 @@
 global $hubspot_form_block_instance_ids;
 
 $portal_id = $attributes['portalId'] ?: get_option( 'hubspot_embed_portal_id' );
+$region = $attributes['region'] ?: get_option( 'hubspot_embed_region', 'eu1' );
 $form_id = $attributes['formId'] ?: '';
 
 if ( empty( $portal_id ) || empty( $form_id ) ) {
@@ -28,6 +29,7 @@ $target = sprintf(
 // Generate config object.
 $config = [
 	'portalId' => $portal_id,
+	'region' => $region,
 	'formId' => $form_id,
 	'locale' => mb_substr( get_locale(), 0, 2 ),
 	'target' => sprintf( '#%s', $target ),


### PR DESCRIPTION
I spotted an issues with our hubspot form implementation. 

* Main issue is we're loading the region specific tracking script e.g. `https://js-eu1.hs-scripts.com/123.js`, but not doing the same for the form script. The default (`js.`) is North America. Should update that to match.
* The documentation suggests the region prefix in the script src should be either `js-eu1.` or `js.`. If you specify north america, you currently get `js-na1` which works fine, but is not documented. 
* Secondly, we're loading the form script `https://js.hsforms.net/forms/v2.js` but I can't find any mention of this file in the documentation. All references use `https://js.hsforms.net/forms/embed/v2.js`. update to match current documentation. Note  actual files are currently identical.
* Finally, I think we should specify the region when calling `hbspt.forms.create` [the docs don't say it's optional - and don't say what it defaults to. ](https://developers.hubspot.com/docs/cms/start-building/features/forms/legacy-forms). This is "The region of the account where the form was created.". We currently do nothing with this value. But we should add it to the config and I think it should behave like `portalId` by allowing you to set on global or block level. 

I'm slightly unsure if there are there potential problems loading scripts from one region and then specifying the form for another?