### PR TITLE
Add persist success option to remember form submissions via localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A WordPress block plugin that embeds HubSpot Forms v4 directly in page content. 
 
 - **HubSpot Forms v4 API** — uses the modern developer embed API
 - **Inline success message** — add any WordPress blocks as the post-submission message; shown in place of the form after submission
+- **Gated content** — optionally remember submissions in the browser (per page URL) and show the success content immediately on return visits, hiding the form permanently; supports a "First Submission Message" block for content only shown at the moment of first submission
 - **Global settings** — set Portal ID and region site-wide; override per block instance
 - **Google Tag Manager** — fires a configurable dataLayer event on submission (default: `hubspot_form_submit`)
 - **Deferred script loading** — HubSpot tracking JS loaded asynchronously in the footer
@@ -24,6 +25,7 @@ A WordPress block plugin that embeds HubSpot Forms v4 directly in page content. 
 | Submit button text | Override the form's submit button label. |
 | GTM event name | dataLayer event name pushed on submission. Defaults to `hubspot_form_submit`. |
 | Success message (inner blocks) | WordPress blocks shown in place of the form after successful submission. Not shown if a redirect URL is set. |
+| Enable gated content | When on, the browser remembers that this form has been submitted on this page (stored in `localStorage`). Returning visitors see the success message immediately instead of the form. Use the "Insert First Submission Message" button to add a block whose content is only shown at the moment of the first submission — stripped on subsequent visits. Disabled when a redirect URL is set. |
 
 ## Global settings
 
@@ -76,6 +78,8 @@ hubspot-form-block.php  # Plugin entry: block registration, script enqueue, sett
 **Config injection:** Each form instance gets a unique target ID (`hubspot-form-{formId}-{n}`). A `<script>` block writes `window.hsForms[target] = {...config}` so `view.js` can pick it up when HubSpot fires `hs-form-event:on-ready`.
 
 **Success message:** When inner blocks are present and no redirect URL is set, `render.php` emits a `<template id="{target}-inline-message">` containing the server-rendered block HTML. On `hs-form-event:on-submission:success`, `view.js` clones the template content into the form container, replacing the form with the success message.
+
+**Gated content (`persistSuccess`):** When enabled, `view.js` writes the current `window.location.pathname` into a `localStorage` entry keyed `hs-form-submitted:{formId}` (value is a JSON array of paths, so the same form on different URLs is tracked independently). A synchronous inline `<script>` emitted by `render.php` checks this array on page load and pre-swaps the container before paint if the current path is present, preventing HubSpot from rendering the form at all. Any inner `core/group` block with class `is-hubspot-form-first-submission` (the "First Submission Message" variation) is stripped from the clone during pre-swap but preserved for the fresh-submission path.
 
 ## Release workflow
 

--- a/src/block.json
+++ b/src/block.json
@@ -31,6 +31,10 @@
 		},
 		"gtmEventName": {
 			"type": "string"
+		},
+		"persistSuccess": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"description": "Hubspot form embed block with configuration options",

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,4 +1,4 @@
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	InspectorControls,
@@ -6,10 +6,15 @@ import {
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import {
+	registerBlockVariation,
+	unregisterBlockVariation,
+} from '@wordpress/blocks';
+import {
 	Button,
 	PanelBody,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import './editor.scss';
@@ -21,11 +26,12 @@ import './editor.scss';
  * @param {Object}   root0               - Block props object
  * @param {Object}   root0.attributes    - Block attributes
  * @param {Function} root0.setAttributes - Function to set block attributes
+ * @param {string}   root0.clientId      - Block client ID
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @return {JSX.Element} Element to render.
  */
-export default function Edit( { attributes, setAttributes } ) {
+export default function Edit( { attributes, setAttributes, clientId } ) {
 	const { ...blockProps } = useBlockProps();
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		template: [
@@ -41,10 +47,53 @@ export default function Edit( { attributes, setAttributes } ) {
 		],
 	} );
 
-	const { portalId, region, formId, redirectUrl, submitText, gtmEventName } =
-		attributes;
+	const {
+		portalId,
+		region,
+		formId,
+		redirectUrl,
+		submitText,
+		gtmEventName,
+		persistSuccess,
+	} = attributes;
 
 	const [ isGlobalChanged, setIsGlobalChanged ] = useState( false );
+
+	const isActiveContext = useSelect(
+		( select ) => {
+			const { getSelectedBlockClientId, hasSelectedInnerBlock } =
+				select( 'core/block-editor' );
+			const selectedId = getSelectedBlockClientId();
+			return (
+				selectedId === clientId ||
+				hasSelectedInnerBlock( clientId, true )
+			);
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		if ( ! isActiveContext || ! persistSuccess ) {
+			return;
+		}
+		registerBlockVariation( 'core/group', {
+			name: 'hubspot-form-first-submission',
+			title: __( 'First Submission Message', 'hubspot-form-block' ),
+			description: __(
+				'Content shown only after the first successful submission on this page load.',
+				'hubspot-form-block'
+			),
+			attributes: { className: 'is-hubspot-form-first-submission' },
+			isActive: ( attrs ) =>
+				attrs.className?.includes( 'is-hubspot-form-first-submission' ),
+			scope: [ 'inserter' ],
+		} );
+		return () =>
+			unregisterBlockVariation(
+				'core/group',
+				'hubspot-form-first-submission'
+			);
+	}, [ isActiveContext, persistSuccess ] );
 
 	const {
 		canSetPortalId,
@@ -160,6 +209,21 @@ export default function Edit( { attributes, setAttributes } ) {
 						onChange={ ( newGtmEventName ) =>
 							setAttributes( { gtmEventName: newGtmEventName } )
 						}
+					/>
+					<ToggleControl
+						label={ __(
+							'Only show success message on first submission',
+							'hubspot-form-block'
+						) }
+						help={ __(
+							'Remember submissions in this browser. Insert a "First Submission Message" group for content that only shows once.',
+							'hubspot-form-block'
+						) }
+						checked={ persistSuccess }
+						onChange={ ( value ) =>
+							setAttributes( { persistSuccess: value } )
+						}
+						disabled={ !! redirectUrl }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/edit.js
+++ b/src/edit.js
@@ -6,6 +6,7 @@ import {
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import {
+	createBlock,
 	registerBlockVariation,
 	unregisterBlockVariation,
 } from '@wordpress/blocks';
@@ -109,6 +110,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		};
 	} );
 
+	const { insertBlock } = useDispatch( 'core/block-editor' );
 	const { saveSite } = useDispatch( 'core' );
 	const updateDefaults = ( newPortalId, newRegion ) =>
 		saveSite( {
@@ -212,11 +214,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					/>
 					<ToggleControl
 						label={ __(
-							'Only show success message on first submission',
+							'Enable gated content',
 							'hubspot-form-block'
 						) }
 						help={ __(
-							'Remember submissions in this browser. Insert a "First Submission Message" group for content that only shows once.',
+							'Remembers submissions in this browser per page. Use the "First Submission Message" block inside the success message area for content only shown immediately after submitting.',
 							'hubspot-form-block'
 						) }
 						checked={ persistSuccess }
@@ -264,11 +266,47 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			) }
 			<div className="wp-hubspot-form-block__inline-message-wrapper">
 				<p className="wp-hubspot-form-block__inline-message-label">
-					{ __(
-						'Success message — shown in place of the form after submission',
-						'hubspot-form-block'
-					) }
+					{ persistSuccess
+						? __(
+								'Gated content — shown in place of the form after submission. Returning visitors see everything except the "First Submission Message" block.',
+								'hubspot-form-block'
+						  )
+						: __(
+								'Success message — shown in place of the form after submission',
+								'hubspot-form-block'
+						  ) }
 				</p>
+				{ persistSuccess && (
+					<Button
+						variant="secondary"
+						onClick={ () => {
+							insertBlock(
+								createBlock(
+									'core/group',
+									{
+										className:
+											'is-hubspot-form-first-submission',
+									},
+									[
+										createBlock( 'core/paragraph', {
+											content: __(
+												'Success!',
+												'hubspot-form-block'
+											),
+										} ),
+									]
+								),
+								undefined,
+								clientId
+							);
+						} }
+					>
+						{ __(
+							'Insert First Submission Message',
+							'hubspot-form-block'
+						) }
+					</Button>
+				) }
 				<div className="wp-hubspot-form-block__inline-message">
 					{ children }
 				</div>

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -18,6 +18,10 @@
 	padding-top: 12px;
 }
 
+.wp-hubspot-form-block__inline-message-wrapper > .components-button {
+	margin-bottom: 12px;
+}
+
 .wp-hubspot-form-block__inline-message-label {
 	font-size: 11px;
 	font-weight: 600;

--- a/src/render.php
+++ b/src/render.php
@@ -109,7 +109,10 @@ $wrapper_attributes = [
 				n.remove();
 			} );
 			el.replaceChildren( frag );
-			el.dataset.hsFormSubmitted = '1';
+			el.removeAttribute( 'data-form-id' );
+			el.removeAttribute( 'data-portal-id' );
+			el.removeAttribute( 'data-region' );
+			el.classList.remove( 'hs-form-html' );
 		} catch ( e ) {}
 	} )();
 </script>

--- a/src/render.php
+++ b/src/render.php
@@ -94,8 +94,9 @@ $wrapper_attributes = [
 			if ( ! cfg || ! cfg.persistSuccess || ! cfg.storageKey ) {
 				return;
 			}
-			var key = cfg.storageKey + ':' + window.location.pathname;
-			if ( localStorage.getItem( key ) !== '1' ) {
+			var paths = [];
+			try { paths = JSON.parse( localStorage.getItem( cfg.storageKey ) || '[]' ); } catch ( e ) {}
+			if ( ! Array.isArray( paths ) || ! paths.includes( window.location.pathname ) ) {
 				return;
 			}
 			var tmpl = document.getElementById( '<?php echo esc_js( $target ); ?>-inline-message' );

--- a/src/render.php
+++ b/src/render.php
@@ -42,6 +42,11 @@ foreach ( $optional_config as $key => $callback ) {
 	}
 }
 
+if ( ! empty( $attributes['persistSuccess'] ) && empty( $config['redirectUrl'] ) ) {
+	$config['persistSuccess'] = true;
+	$config['storageKey']     = 'hs-form-submitted:' . $form_id;
+}
+
 // Add inline message if inner blocks present.
 $has_inline_message = (
 	! isset( $config['redirectUrl'] ) &&
@@ -81,3 +86,29 @@ $wrapper_attributes = [
 		<p><?php esc_html_e( 'This form may not be visible due to adblockers, or JavaScript not being enabled.', 'hubspot-form-block' ); ?></p>
 	</noscript>
 </div>
+<?php if ( $has_inline_message && ! empty( $attributes['persistSuccess'] ) ) : ?>
+<script type="text/javascript">
+	( function () {
+		try {
+			var cfg = window.hsForms && window.hsForms[ '<?php echo esc_js( $target ); ?>' ];
+			if ( ! cfg || ! cfg.persistSuccess || ! cfg.storageKey ) {
+				return;
+			}
+			if ( localStorage.getItem( cfg.storageKey ) !== '1' ) {
+				return;
+			}
+			var tmpl = document.getElementById( '<?php echo esc_js( $target ); ?>-inline-message' );
+			var el   = document.getElementById( '<?php echo esc_js( $target ); ?>' );
+			if ( ! tmpl || ! el ) {
+				return;
+			}
+			var frag = tmpl.content.cloneNode( true );
+			frag.querySelectorAll( '.is-hubspot-form-first-submission' ).forEach( function ( n ) {
+				n.remove();
+			} );
+			el.replaceChildren( frag );
+			el.dataset.hsFormSubmitted = '1';
+		} catch ( e ) {}
+	} )();
+</script>
+<?php endif; ?>

--- a/src/render.php
+++ b/src/render.php
@@ -94,7 +94,8 @@ $wrapper_attributes = [
 			if ( ! cfg || ! cfg.persistSuccess || ! cfg.storageKey ) {
 				return;
 			}
-			if ( localStorage.getItem( cfg.storageKey ) !== '1' ) {
+			var key = cfg.storageKey + ':' + window.location.pathname;
+			if ( localStorage.getItem( key ) !== '1' ) {
 				return;
 			}
 			var tmpl = document.getElementById( '<?php echo esc_js( $target ); ?>-inline-message' );

--- a/src/view.js
+++ b/src/view.js
@@ -61,7 +61,10 @@ window.addEventListener( 'hs-form-event:on-submission:success', ( event ) => {
 
 	if ( config.persistSuccess && config.storageKey ) {
 		try {
-			localStorage.setItem( config.storageKey, '1' );
+			localStorage.setItem(
+				config.storageKey + ':' + window.location.pathname,
+				'1'
+			);
 		} catch ( e ) {}
 	}
 } );

--- a/src/view.js
+++ b/src/view.js
@@ -61,10 +61,16 @@ window.addEventListener( 'hs-form-event:on-submission:success', ( event ) => {
 
 	if ( config.persistSuccess && config.storageKey ) {
 		try {
-			localStorage.setItem(
-				config.storageKey + ':' + window.location.pathname,
-				'1'
+			const paths = JSON.parse(
+				localStorage.getItem( config.storageKey ) || '[]'
 			);
+			if ( ! paths.includes( window.location.pathname ) ) {
+				paths.push( window.location.pathname );
+				localStorage.setItem(
+					config.storageKey,
+					JSON.stringify( paths )
+				);
+			}
 		} catch ( e ) {}
 	}
 } );

--- a/src/view.js
+++ b/src/view.js
@@ -1,4 +1,4 @@
-/* global HubSpotFormsV4, dataLayer */
+/* global HubSpotFormsV4, dataLayer, localStorage */
 
 window.addEventListener( 'hs-form-event:on-ready', ( event ) => {
 	window.hsForms = window.hsForms || {};
@@ -7,6 +7,11 @@ window.addEventListener( 'hs-form-event:on-ready', ( event ) => {
 	const config = window.hsForms[ instanceId ];
 
 	if ( ! config ) {
+		return;
+	}
+
+	const element = document.getElementById( instanceId );
+	if ( element?.dataset.hsFormSubmitted === '1' ) {
 		return;
 	}
 
@@ -52,5 +57,11 @@ window.addEventListener( 'hs-form-event:on-submission:success', ( event ) => {
 	if ( template && template.content ) {
 		const element = document.getElementById( instanceId );
 		element.replaceChildren( template.content.cloneNode( true ) );
+	}
+
+	if ( config.persistSuccess && config.storageKey ) {
+		try {
+			localStorage.setItem( config.storageKey, '1' );
+		} catch ( e ) {}
 	}
 } );

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -9,4 +9,50 @@ function editorCanvas( page ) {
 	return page.locator( 'iframe[name="editor-canvas"]' ).contentFrame();
 }
 
-module.exports = { editorCanvas };
+/**
+ * Dispatches a mocked hs-form-event:on-submission:success event for a given
+ * HubSpot form instance. Stubs HubSpotFormsV4.getFormFromEvent to return a
+ * minimal form object so view.js event handlers fire correctly.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string}                          instanceId The form container id.
+ * @param {string}                          formId     The HubSpot form id.
+ */
+async function dispatchHubSpotSuccess( page, instanceId, formId ) {
+	await page.evaluate(
+		( [ id, fId ] ) => {
+			window.HubSpotFormsV4 = {
+				getFormFromEvent: () => ( {
+					getInstanceId: () => id,
+					getFormId: () => fId,
+					getConversionId: () => 'test-conversion-id',
+				} ),
+			};
+			window.dataLayer = window.dataLayer || [];
+			window.dispatchEvent(
+				new Event( 'hs-form-event:on-submission:success' )
+			);
+		},
+		[ instanceId, formId ]
+	);
+}
+
+/**
+ * Seeds localStorage with the form-submitted flag before the page navigates,
+ * so the pre-swap inline script in render.php fires on page load.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string}                          formId The HubSpot form id.
+ */
+async function presetFormSubmittedFlag( page, formId ) {
+	await page.addInitScript( ( fId ) => {
+		// eslint-disable-next-line no-undef
+		localStorage.setItem( `hs-form-submitted:${ fId }`, '1' );
+	}, formId );
+}
+
+module.exports = {
+	editorCanvas,
+	dispatchHubSpotSuccess,
+	presetFormSubmittedFlag,
+};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -47,7 +47,10 @@ async function dispatchHubSpotSuccess( page, instanceId, formId ) {
 async function presetFormSubmittedFlag( page, formId ) {
 	await page.addInitScript( ( fId ) => {
 		// eslint-disable-next-line no-undef
-		localStorage.setItem( `hs-form-submitted:${ fId }`, '1' );
+		localStorage.setItem(
+			`hs-form-submitted:${ fId }:${ window.location.pathname }`,
+			'1'
+		);
 	}, formId );
 }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -48,8 +48,8 @@ async function presetFormSubmittedFlag( page, formId ) {
 	await page.addInitScript( ( fId ) => {
 		// eslint-disable-next-line no-undef
 		localStorage.setItem(
-			`hs-form-submitted:${ fId }:${ window.location.pathname }`,
-			'1'
+			`hs-form-submitted:${ fId }`,
+			JSON.stringify( [ window.location.pathname ] )
 		);
 	}, formId );
 }

--- a/tests/persist-success.spec.js
+++ b/tests/persist-success.spec.js
@@ -257,16 +257,26 @@ test.describe( 'HubSpot Form — persist success', () => {
 			page.locator( `#${ instanceId } .is-hubspot-form-first-submission` )
 		).toBeAttached();
 
-		// The localStorage flag should be set for this URL.
-		const flag = await page.evaluate(
-			( formId ) =>
-				// eslint-disable-next-line no-undef
-				localStorage.getItem(
-					`hs-form-submitted:${ formId }:${ window.location.pathname }`
-				),
-			FORM_ID
-		);
-		expect( flag ).toBe( '1' );
+		// The localStorage entry should be an array containing the current pathname.
+		const { stored, pathname } = await page.evaluate( ( formId ) => {
+			try {
+				return {
+					// eslint-disable-next-line no-undef
+					stored: JSON.parse(
+						// eslint-disable-next-line no-undef
+						localStorage.getItem(
+							`hs-form-submitted:${ formId }`
+						) || '[]'
+					),
+					// eslint-disable-next-line no-undef
+					pathname: window.location.pathname,
+				};
+			} catch ( e ) {
+				return { stored: [], pathname: '' };
+			}
+		}, FORM_ID );
+		expect( Array.isArray( stored ) ).toBe( true );
+		expect( stored ).toContain( pathname );
 	} );
 
 	test( 'should pre-swap the container on repeat visit, stripping the first-submission group', async ( {

--- a/tests/persist-success.spec.js
+++ b/tests/persist-success.spec.js
@@ -1,0 +1,338 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const {
+	dispatchHubSpotSuccess,
+	presetFormSubmittedFlag,
+} = require( './helpers' );
+
+const PORTAL_ID = '148262752';
+const FORM_ID = 'ec0707d2-b7f5-47c5-bfef-76eb7e8f837e';
+
+test.describe( 'HubSpot Form — persist success', () => {
+	test( 'should include persistSuccess and storageKey in injected config when enabled', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+				persistSuccess: true,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Thank you!' },
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		const config = await page.evaluate(
+			( id ) => window.hsForms?.[ id ],
+			instanceId
+		);
+
+		expect( config.persistSuccess ).toBe( true );
+		expect( config.storageKey ).toBe( `hs-form-submitted:${ FORM_ID }` );
+	} );
+
+	test( 'should not include persistSuccess or storageKey when not enabled', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Thank you!' },
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		const config = await page.evaluate(
+			( id ) => window.hsForms?.[ id ],
+			instanceId
+		);
+
+		expect( config.persistSuccess ).toBeUndefined();
+		expect( config.storageKey ).toBeUndefined();
+	} );
+
+	test( 'should not include persistSuccess when redirectUrl is set', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+				persistSuccess: true,
+				redirectUrl: 'https://example.com/thanks',
+			},
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		const config = await page.evaluate(
+			( id ) => window.hsForms?.[ id ],
+			instanceId
+		);
+
+		expect( config.persistSuccess ).toBeUndefined();
+		expect( config.storageKey ).toBeUndefined();
+	} );
+
+	test( 'should include the first-submission group in the <template>', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+				persistSuccess: true,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Thank you!' },
+				},
+				{
+					name: 'core/group',
+					attributes: {
+						className: 'is-hubspot-form-first-submission',
+					},
+					innerBlocks: [
+						{
+							name: 'core/heading',
+							attributes: {
+								content: 'One-time only message',
+								level: 3,
+							},
+						},
+					],
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		const hasFirstSubmissionGroup = await page.evaluate( ( id ) => {
+			const tmpl = document.getElementById( `${ id }-inline-message` );
+			if ( ! tmpl ) {
+				return false;
+			}
+			return (
+				tmpl.content.querySelector(
+					'.is-hubspot-form-first-submission'
+				) !== null
+			);
+		}, instanceId );
+
+		expect( hasFirstSubmissionGroup ).toBe( true );
+	} );
+
+	test( 'should show full inline message including first-submission group on fresh success', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+				persistSuccess: true,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Thank you!' },
+				},
+				{
+					name: 'core/group',
+					attributes: {
+						className: 'is-hubspot-form-first-submission',
+					},
+					innerBlocks: [
+						{
+							name: 'core/heading',
+							attributes: {
+								content: 'One-time only message',
+								level: 3,
+							},
+						},
+					],
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		await dispatchHubSpotSuccess( page, instanceId, FORM_ID );
+
+		// The container should now show the full inline message.
+		await expect(
+			page.locator( `#${ instanceId } p` ).filter( {
+				hasText: 'Thank you!',
+			} )
+		).toBeAttached();
+
+		// The first-submission group should still be present on first success.
+		await expect(
+			page.locator( `#${ instanceId } .is-hubspot-form-first-submission` )
+		).toBeAttached();
+
+		// The localStorage flag should be set.
+		const flag = await page.evaluate(
+			( formId ) =>
+				// eslint-disable-next-line no-undef
+				localStorage.getItem( `hs-form-submitted:${ formId }` ),
+			FORM_ID
+		);
+		expect( flag ).toBe( '1' );
+	} );
+
+	test( 'should pre-swap the container on repeat visit, stripping the first-submission group', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
+		await editor.insertBlock( {
+			name: 'hubspot/form',
+			attributes: {
+				portalId: PORTAL_ID,
+				region: 'na1',
+				formId: FORM_ID,
+				persistSuccess: true,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Thank you!' },
+				},
+				{
+					name: 'core/group',
+					attributes: {
+						className: 'is-hubspot-form-first-submission',
+					},
+					innerBlocks: [
+						{
+							name: 'core/heading',
+							attributes: {
+								content: 'One-time only message',
+								level: 3,
+							},
+						},
+					],
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+
+		// Seed localStorage before navigation to simulate a returning visitor.
+		await presetFormSubmittedFlag( page, FORM_ID );
+		await page.goto( `/?p=${ postId }` );
+
+		const container = page.locator( '.hs-form-html' );
+		await expect( container ).toBeAttached();
+		const instanceId = await container.getAttribute( 'id' );
+
+		// The success paragraph should be visible (pre-swapped).
+		await expect(
+			page.locator( `#${ instanceId } p` ).filter( {
+				hasText: 'Thank you!',
+			} )
+		).toBeAttached();
+
+		// The first-submission group should have been stripped.
+		await expect(
+			page.locator( `#${ instanceId } .is-hubspot-form-first-submission` )
+		).not.toBeAttached();
+
+		// The loading spinner should not remain.
+		await expect(
+			page.locator( `#${ instanceId } .wp-block-hubspot-form__loading` )
+		).not.toBeAttached();
+	} );
+} );

--- a/tests/persist-success.spec.js
+++ b/tests/persist-success.spec.js
@@ -326,16 +326,25 @@ test.describe( 'HubSpot Form — persist success', () => {
 		await presetFormSubmittedFlag( page, FORM_ID );
 		await page.goto( `/?p=${ postId }` );
 
-		const container = page.locator( '.hs-form-html' );
-		await expect( container ).toBeAttached();
-		const instanceId = await container.getAttribute( 'id' );
+		// The container element keeps its id even after the pre-swap strips
+		// HubSpot's data attributes, so look it up by id via the template.
+		const instanceId = await page.evaluate( () => {
+			const tmpl = document.querySelector(
+				'template[id$="-inline-message"]'
+			);
+			return tmpl ? tmpl.id.replace( '-inline-message', '' ) : null;
+		} );
 
-		// The success paragraph should be visible (pre-swapped).
-		await expect(
-			page.locator( `#${ instanceId } p` ).filter( {
-				hasText: 'Thank you!',
-			} )
-		).toBeAttached();
+		// The success paragraph should be present immediately after pre-swap.
+		const successParagraph = page.locator( `#${ instanceId } p` ).filter( {
+			hasText: 'Thank you!',
+		} );
+		await expect( successParagraph ).toBeAttached();
+
+		// Wait 5 seconds to confirm the HubSpot SDK has not overwritten the
+		// pre-swapped content by re-rendering the form into the container.
+		await page.waitForTimeout( 5000 );
+		await expect( successParagraph ).toBeAttached();
 
 		// The first-submission group should have been stripped.
 		await expect(

--- a/tests/persist-success.spec.js
+++ b/tests/persist-success.spec.js
@@ -257,11 +257,13 @@ test.describe( 'HubSpot Form — persist success', () => {
 			page.locator( `#${ instanceId } .is-hubspot-form-first-submission` )
 		).toBeAttached();
 
-		// The localStorage flag should be set.
+		// The localStorage flag should be set for this URL.
 		const flag = await page.evaluate(
 			( formId ) =>
 				// eslint-disable-next-line no-undef
-				localStorage.getItem( `hs-form-submitted:${ formId }` ),
+				localStorage.getItem(
+					`hs-form-submitted:${ formId }:${ window.location.pathname }`
+				),
 			FORM_ID
 		);
 		expect( flag ).toBe( '1' );


### PR DESCRIPTION
## Summary

- Adds a `persistSuccess` block attribute (toggle in Form Settings) that, when enabled, writes a `localStorage` flag (`hs-form-submitted:{formId}`) after a successful HubSpot form submission
- On subsequent page loads, an inline `<script>` in `render.php` checks localStorage synchronously and pre-swaps the form container with the inline success message before paint — no spinner flash
- Adds a new **"First Submission Message"** `core/group` block variation, registered dynamically via `useEffect` only while the hubspot/form block (or a descendant) is selected and `persistSuccess` is enabled — keeps the variation scoped to the parent without restricting `allowedBlocks`
- Content inside the First Submission Message group is shown on the first success but stripped from the clone when pre-swapping on return visits (`querySelectorAll('.is-hubspot-form-first-submission').forEach(n => n.remove())`)
- The `hs-form-event:on-ready` handler bails early if the container was already pre-swapped (`dataset.hsFormSubmitted === '1'`) so HubSpot doesn't re-render the form
- `persistSuccess` is suppressed when `redirectUrl` is set (redirect supersedes)

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint:js && npm run lint:css` pass (clean)
- [ ] `npm run test:e2e` — all existing specs + new `tests/persist-success.spec.js` pass (6 new tests covering: config emission, negative cases, redirect override, template content, fresh success path, repeat-visit pre-swap)
- [ ] Manual smoke: insert block, toggle persistSuccess on, add inline paragraph + First Submission Message group, publish, submit form → both appear; reload → paragraph only, no spinner, localStorage flag set; clear flag, reload → form re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fhubspot-form-block%26branch%3Dpr-10-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->