### PR TITLE
Fix HubSpot scripts not loading when portal ID is set per-block only

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -123,7 +123,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			<InspectorControls>
 				<PanelBody
 					title={ __( 'Global Settings', 'hubspot-form-block' ) }
-					initialOpen={ ! defaultPortalId && ! portalId }
+					initialOpen={ ! defaultPortalId }
 				>
 					<TextControl
 						label={ __( 'Portal ID', 'hubspot-form-block' ) }

--- a/src/render.php
+++ b/src/render.php
@@ -9,6 +9,28 @@ if ( empty( $portal_id ) || empty( $form_id ) ) {
 	return;
 }
 
+// If no global portal ID is set, the main plugin won't have enqueued the HubSpot
+// scripts — enqueue them here using the block-level portal ID as a fallback.
+if ( empty( get_option( 'hubspot_embed_portal_id' ) ) ) {
+	wp_enqueue_script(
+		"hs-forms-{$portal_id}",
+		sprintf( 'https://js-%s.hsforms.net/forms/embed/developer/%s.js', $region, $portal_id ),
+		[ 'hubspot-form-view-script' ],
+		null,
+		[ 'strategy' => 'async' ]
+	);
+	wp_enqueue_script(
+		"hs-script-loader-{$portal_id}",
+		sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id ),
+		[],
+		null,
+		[
+			'strategy'  => 'async',
+			'in_footer' => true,
+		]
+	);
+}
+
 // Remove empty value attributes.
 $attributes = array_filter( $attributes );
 


### PR DESCRIPTION
## Summary

- When no global portal ID is configured, `render.php` now enqueues `hs-forms` and `hs-script-loader` using the block-level `portalId` attribute as a fallback — previously the main plugin bailed early and the HubSpot JS was never loaded
- Script handles are portal-ID-scoped (`hs-forms-{portalId}`) so multiple blocks with different portal IDs on the same page won't collide
- Fixed the Global Settings panel in the editor closing prematurely when typing a block-level portal ID — `initialOpen` now depends only on the saved global default, not the block attribute

## Test plan

- [ ] Set a portal ID on a block without saving it as the global value — confirm the form renders and HubSpot scripts load
- [ ] Save a global portal ID and confirm existing behaviour is unchanged
- [ ] Confirm the Global Settings panel stays open while typing a portal ID into the block field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fhubspot-form-block%26branch%3Dpr-11-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->