### PR TITLE
Add Business Unit ID support for hs-script-loader

### DIFF
--- a/hubspot-form-block.php
+++ b/hubspot-form-block.php
@@ -54,11 +54,17 @@ function enqueue_scripts() {
 		return;
 	}
 
-	$region = get_option( 'hubspot_embed_region', 'eu1' );
+	$region           = get_option( 'hubspot_embed_region', 'eu1' );
+	$business_unit_id = absint( get_option( 'hubspot_embed_business_unit_id' ) );
+	$url              = sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id );
+
+	if ( ! empty( $business_unit_id ) ) {
+		$url = add_query_arg( 'businessUnitId', $business_unit_id, $url );
+	}
 
 	wp_enqueue_script(
 		'hs-script-loader',
-		sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id ),
+		$url,
 		[],
 		null,
 		[
@@ -93,6 +99,15 @@ function rest_api() {
 			},
 			'show_in_rest' => true,
 			'default' => 'eu1',
+		]
+	);
+	register_setting(
+		'hubspot_embed',
+		'hubspot_embed_business_unit_id',
+		[
+			'type' => 'integer',
+			'sanitize_callback' => 'absint',
+			'show_in_rest' => true,
 		]
 	);
 }

--- a/src/block.json
+++ b/src/block.json
@@ -8,8 +8,8 @@
 	"icon": "clipboard",
 	"attributes": {
 		"portalId": {
-			"type": "integer",
-			"default": 0
+			"type": [ "integer", "null" ],
+			"default": null
 		},
 		"region": {
 			"type": "string",
@@ -37,8 +37,8 @@
 			"default": false
 		},
 		"businessUnitId": {
-			"type": "integer",
-			"default": 0
+			"type": [ "integer", "null" ],
+			"default": null
 		}
 	},
 	"description": "Hubspot form embed block with configuration options",

--- a/src/block.json
+++ b/src/block.json
@@ -35,6 +35,9 @@
 		"persistSuccess": {
 			"type": "boolean",
 			"default": false
+		},
+		"businessUnitId": {
+			"type": "integer"
 		}
 	},
 	"description": "Hubspot form embed block with configuration options",

--- a/src/block.json
+++ b/src/block.json
@@ -8,8 +8,8 @@
 	"icon": "clipboard",
 	"attributes": {
 		"portalId": {
-			"type": "string",
-			"default": ""
+			"type": "integer",
+			"default": 0
 		},
 		"region": {
 			"type": "string",
@@ -37,8 +37,8 @@
 			"default": false
 		},
 		"businessUnitId": {
-			"type": "string",
-			"default": ""
+			"type": "integer",
+			"default": 0
 		}
 	},
 	"description": "Hubspot form embed block with configuration options",

--- a/src/block.json
+++ b/src/block.json
@@ -37,7 +37,8 @@
 			"default": false
 		},
 		"businessUnitId": {
-			"type": "integer"
+			"type": "string",
+			"default": ""
 		}
 	},
 	"description": "Hubspot form embed block with configuration options",

--- a/src/edit.js
+++ b/src/edit.js
@@ -56,6 +56,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		submitText,
 		gtmEventName,
 		persistSuccess,
+		businessUnitId,
 	} = attributes;
 
 	const [ isGlobalChanged, setIsGlobalChanged ] = useState( false );
@@ -100,6 +101,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		canSetPortalId,
 		defaultPortalId = '',
 		defaultRegion,
+		defaultBusinessUnitId,
 	} = useSelect( ( select ) => {
 		const settings = select( 'core' ).getSite();
 
@@ -107,15 +109,18 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			canSetPortalId: select( 'core' ).canUser( 'update', 'settings' ),
 			defaultPortalId: settings?.hubspot_embed_portal_id || '',
 			defaultRegion: settings?.hubspot_embed_region || 'eu1',
+			defaultBusinessUnitId:
+				settings?.hubspot_embed_business_unit_id || '',
 		};
 	} );
 
 	const { insertBlock } = useDispatch( 'core/block-editor' );
 	const { saveSite } = useDispatch( 'core' );
-	const updateDefaults = ( newPortalId, newRegion ) =>
+	const updateDefaults = ( newPortalId, newRegion, newBusinessUnitId ) =>
 		saveSite( {
 			hubspot_embed_portal_id: newPortalId,
 			hubspot_embed_region: newRegion,
+			hubspot_embed_business_unit_id: newBusinessUnitId || 0,
 		} );
 
 	return (
@@ -134,6 +139,27 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							setIsGlobalChanged( true );
 						} }
 						required={ ! defaultPortalId }
+					/>
+					<TextControl
+						label={ __( 'Business Unit ID', 'hubspot-form-block' ) }
+						type="number"
+						min="1"
+						step="1"
+						value={
+							businessUnitId !== undefined
+								? String( businessUnitId )
+								: ''
+						}
+						placeholder={ String( defaultBusinessUnitId ) }
+						onChange={ ( value ) => {
+							const parsed = parseInt( value, 10 );
+							setAttributes( {
+								businessUnitId: isNaN( parsed )
+									? undefined
+									: parsed,
+							} );
+							setIsGlobalChanged( true );
+						} }
 					/>
 					<SelectControl
 						label={ __( 'Region', 'hubspot-form-block' ) }
@@ -161,8 +187,15 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						<Button
 							variant="secondary"
 							onClick={ () => {
-								setAttributes( { portalId: '' } );
-								updateDefaults( portalId, region );
+								setAttributes( {
+									portalId: '',
+									businessUnitId: undefined,
+								} );
+								updateDefaults(
+									portalId,
+									region,
+									businessUnitId
+								);
 								setIsGlobalChanged( false );
 							} }
 						>

--- a/src/edit.js
+++ b/src/edit.js
@@ -132,21 +132,25 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				>
 					<TextControl
 						label={ __( 'Portal ID', 'hubspot-form-block' ) }
-						value={ portalId }
-						placeholder={ defaultPortalId }
-						onChange={ ( newPortalId ) => {
-							setAttributes( { portalId: newPortalId } );
+						value={ portalId ? String( portalId ) : '' }
+						placeholder={ String( defaultPortalId ) }
+						onChange={ ( value ) => {
+							const parsed = parseInt( value, 10 );
+							setAttributes( {
+								portalId: isNaN( parsed ) ? 0 : parsed,
+							} );
 							setIsGlobalChanged( true );
 						} }
 						required={ ! defaultPortalId }
 					/>
 					<TextControl
 						label={ __( 'Business Unit ID', 'hubspot-form-block' ) }
-						value={ businessUnitId }
+						value={ businessUnitId ? String( businessUnitId ) : '' }
 						placeholder={ String( defaultBusinessUnitId ) }
-						onChange={ ( newBusinessUnitId ) => {
+						onChange={ ( value ) => {
+							const parsed = parseInt( value, 10 );
 							setAttributes( {
-								businessUnitId: newBusinessUnitId,
+								businessUnitId: isNaN( parsed ) ? 0 : parsed,
 							} );
 							setIsGlobalChanged( true );
 						} }
@@ -178,8 +182,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							variant="secondary"
 							onClick={ () => {
 								setAttributes( {
-									portalId: '',
-									businessUnitId: '',
+									portalId: 0,
+									businessUnitId: 0,
 								} );
 								updateDefaults(
 									portalId,

--- a/src/edit.js
+++ b/src/edit.js
@@ -142,18 +142,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					/>
 					<TextControl
 						label={ __( 'Business Unit ID', 'hubspot-form-block' ) }
-						value={
-							businessUnitId !== undefined
-								? String( businessUnitId )
-								: ''
-						}
+						value={ businessUnitId }
 						placeholder={ String( defaultBusinessUnitId ) }
-						onChange={ ( value ) => {
-							const parsed = parseInt( value, 10 );
+						onChange={ ( newBusinessUnitId ) => {
 							setAttributes( {
-								businessUnitId: isNaN( parsed )
-									? undefined
-									: parsed,
+								businessUnitId: newBusinessUnitId,
 							} );
 							setIsGlobalChanged( true );
 						} }
@@ -186,7 +179,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							onClick={ () => {
 								setAttributes( {
 									portalId: '',
-									businessUnitId: undefined,
+									businessUnitId: '',
 								} );
 								updateDefaults(
 									portalId,

--- a/src/edit.js
+++ b/src/edit.js
@@ -137,7 +137,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						onChange={ ( value ) => {
 							const parsed = parseInt( value, 10 );
 							setAttributes( {
-								portalId: isNaN( parsed ) ? 0 : parsed,
+								portalId: isNaN( parsed ) ? null : parsed,
 							} );
 							setIsGlobalChanged( true );
 						} }
@@ -150,7 +150,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						onChange={ ( value ) => {
 							const parsed = parseInt( value, 10 );
 							setAttributes( {
-								businessUnitId: isNaN( parsed ) ? 0 : parsed,
+								businessUnitId: isNaN( parsed ) ? null : parsed,
 							} );
 							setIsGlobalChanged( true );
 						} }
@@ -182,8 +182,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							variant="secondary"
 							onClick={ () => {
 								setAttributes( {
-									portalId: 0,
-									businessUnitId: 0,
+									portalId: null,
+									businessUnitId: null,
 								} );
 								updateDefaults(
 									portalId,

--- a/src/edit.js
+++ b/src/edit.js
@@ -142,9 +142,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					/>
 					<TextControl
 						label={ __( 'Business Unit ID', 'hubspot-form-block' ) }
-						type="number"
-						min="1"
-						step="1"
 						value={
 							businessUnitId !== undefined
 								? String( businessUnitId )

--- a/src/render.php
+++ b/src/render.php
@@ -1,9 +1,12 @@
 <?php
 global $hubspot_form_block_instance_ids;
 
-$portal_id = $attributes['portalId'] ?: get_option( 'hubspot_embed_portal_id' );
-$region = $attributes['region'] ?: get_option( 'hubspot_embed_region', 'eu1' );
-$form_id = $attributes['formId'] ?: '';
+$portal_id        = $attributes['portalId'] ?: get_option( 'hubspot_embed_portal_id' );
+$region           = $attributes['region'] ?: get_option( 'hubspot_embed_region', 'eu1' );
+$form_id          = $attributes['formId'] ?: '';
+$business_unit_id = ! empty( $attributes['businessUnitId'] )
+	? absint( $attributes['businessUnitId'] )
+	: absint( get_option( 'hubspot_embed_business_unit_id' ) );
 
 if ( empty( $portal_id ) || empty( $form_id ) ) {
 	return;
@@ -19,9 +22,15 @@ if ( empty( get_option( 'hubspot_embed_portal_id' ) ) ) {
 		null,
 		[ 'strategy' => 'async' ]
 	);
+
+	$hs_script_url = sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id );
+	if ( ! empty( $business_unit_id ) ) {
+		$hs_script_url = add_query_arg( 'businessUnitId', $business_unit_id, $hs_script_url );
+	}
+
 	wp_enqueue_script(
 		"hs-script-loader-{$portal_id}",
-		sprintf( 'https://js-%s.hs-scripts.com/%s.js', $region, $portal_id ),
+		$hs_script_url,
 		[],
 		null,
 		[


### PR DESCRIPTION
## Summary

- Adds an optional **Business Unit ID** integer field to the Global Settings panel in the block editor, positioned after Portal ID
- When set, appends `?businessUnitId=<id>` to the HubSpot tracking script URL (`hs-scripts.com`) — both for the globally enqueued script and the per-block fallback
- Follows the same global/per-block pattern as Portal ID: stored in `hubspot_embed_business_unit_id` site option (exposed via REST API), can be set globally via "Set as global defaults" or overridden per block

## Test plan

- [ ] Set a Business Unit ID globally via the block editor sidebar → confirm `?businessUnitId=X` appears on the `hs-scripts.com` script tag in page source
- [ ] Set a Business Unit ID per-block only (no global Portal ID) → confirm the per-block fallback script also includes the query param
- [ ] Leave Business Unit ID blank → confirm no query param is added to the script URL
- [ ] Set a block-level ID then click "Set as global defaults" → confirm it saves to site options and the block attribute clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fhubspot-form-block%26branch%3Dpr-12-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->